### PR TITLE
Add jointx_is_linear parameter for the linear base

### DIFF
--- a/melfa_driver/include/melfa_driver/melfa_hardware_interface.h
+++ b/melfa_driver/include/melfa_driver/melfa_hardware_interface.h
@@ -44,6 +44,10 @@ private:
   bool use_joint7_;
   // true if use joint8
   bool use_joint8_;
+  // true if joint7 is linear joint
+  bool joint7_is_linear_;
+  // true if joint8 is linear joint
+  bool joint8_is_linear_;
 
   hardware_interface::JointStateInterface joint_state_interface;
   hardware_interface::PositionJointInterface joint_pos_interface;


### PR DESCRIPTION
- Setting `use_joint7` and `joint7_is_linear` parameter true, the linear base is controlled by the driver