### PR TITLE
add rounding to 5 decimal places to command sending to prevent H0117 …

### DIFF
--- a/melfa_driver/include/melfa_driver/melfa_hardware_interface.h
+++ b/melfa_driver/include/melfa_driver/melfa_hardware_interface.h
@@ -62,6 +62,8 @@ private:
   bool joint7_is_linear_;
   // true if joint8 is linear joint
   bool joint8_is_linear_;
+  // true to round the command angle
+  bool round_command_angle_;
 
   hardware_interface::JointStateInterface joint_state_interface;
   hardware_interface::PositionJointInterface joint_pos_interface;

--- a/melfa_driver/src/melfa_hardware_interface.cpp
+++ b/melfa_driver/src/melfa_hardware_interface.cpp
@@ -119,12 +119,16 @@ void MelfaHW::write (void)
   send_buff_.BitTop = 0;
   send_buff_.BitMask = 0;
   send_buff_.IoData = 0;
-  send_buff_.dat.jnt.j1 = cmd[0];
-  send_buff_.dat.jnt.j2 = cmd[1];
-  send_buff_.dat.jnt.j3 = cmd[2];
-  send_buff_.dat.jnt.j4 = cmd[3];
-  send_buff_.dat.jnt.j5 = cmd[4];
-  send_buff_.dat.jnt.j6 = cmd[5];
+
+  // Rounding down to five decimal places -- otherwise small oscillations
+  // from ros_control around 0 seem to cause a H0117 error (power supply error
+  // in the brake) for CR800-D robot control with RV-4FRL-D
+  send_buff_.dat.jnt.j1 = round(cmd[0] * 10000.f) / 10000.f;
+  send_buff_.dat.jnt.j2 = round(cmd[1] * 10000.f) / 10000.f;
+  send_buff_.dat.jnt.j3 = round(cmd[2] * 10000.f) / 10000.f;
+  send_buff_.dat.jnt.j4 = round(cmd[3] * 10000.f) / 10000.f;
+  send_buff_.dat.jnt.j5 = round(cmd[4] * 10000.f) / 10000.f;
+  send_buff_.dat.jnt.j6 = round(cmd[5] * 10000.f) / 10000.f;
   if (joint7_is_linear_)
   {
     // Convert unit to mm


### PR DESCRIPTION
…error

As the comment indicates, and as mentioned in a private message to @7675t we've encountered a H0117 on hardware CR800-D with RV-4FRL-D

The cause seem to have been small oscillations around 0 in joints 4, 5, and 6.

Rounding the command that is sent to the robot to 5 decimal places fixes this issue for us.

Are you fine with this fix?

Best, 

Wolf